### PR TITLE
 Fix for ISO date conversion issue

### DIFF
--- a/lib/xmlrpc-message.js
+++ b/lib/xmlrpc-message.js
@@ -103,7 +103,7 @@ XMLRPCMessage.prototype.toBooleanXML = function (data) {
 
 XMLRPCMessage.prototype.toDateXML = function (data) {
     var xml = "<dateTime.iso8601>";
-    xml += dateToISO8601(data);
+    xml += this.dateToISO8601(data);
     xml += "</dateTime.iso8601>";
     return xml;
 };


### PR DESCRIPTION
Due to a missing `this.` I was getting an error. This corrects the issue
