### PR TITLE
Added text/xml for default response type

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,13 @@
 # xrpc
-      
+
   An XML-RPC server middleware for Express running on Node.js
   built on [node](http://nodejs.org) for [Express](http://expressjs.com/).
-  
+
     var express = require('express'),
         xrpc = require('xrpc'),
         app = express();
 
-    app.configure(function () {
-        app.use(xrpc.xmlRpc);
-    });
+    app.use(xrpc.xmlRpc);
 
     app.post('/RPC', xrpc.route({
         echo: function (msg, callback) {
@@ -30,7 +28,7 @@
   * express middleware
   * platform-independent xml parser
   * includes a router to make using this module dead-simple
-  
+
 ## Examples
 
 See app.js in the example subdirectory for an example implementing one of the metaWeblog API methods
@@ -45,7 +43,7 @@ then run the test:
 
     $ npm test
 
-## License 
+## License
 
 (The MIT License)
 

--- a/example/app.js
+++ b/example/app.js
@@ -6,9 +6,7 @@ var xrpc = require('..');
 
 var app = express();
 
-app.configure(function () {
-    app.use(xrpc.xmlRpc);
-});
+app.use(xrpc.xmlRpc);
 
 // example implementing one of the methods from the metaWeblog API (blogger.getUsersBlogs)
 // to test interaction use Windows Live Writer, MarsEdit, or other metaWeblog-compatible blogging client
@@ -53,7 +51,7 @@ app.post('/RPC', xrpc.route({
        getUserInfo: function(key, username, password, callback) {
            callback(null, { userid: 'user1', firstname: 'James', lastname: 'Hickok', nickname: 'Wild Bill', email: 'bill@hickok.com', url: 'http://billhickok.com', });
        },
-   }    
+   }
 }));
 
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "main": "./xmlrpc.js",
   "dependencies": {
-    "node-xml": ">= 1.0.0"
+    "node-xml": ">= 1.0.0",
     "xmlbuilder": ">= 2.1.0"
   },
   "description": "Express middleware and router support for XML-RPC",

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,3 @@
-
-
 var assert = require('assert');
 
 var os = require('os');
@@ -14,9 +12,7 @@ var app = express();
 
 var data = { test: 999 };
 
-app.configure(function () {
-    app.use(xrpc.xmlRpc);
-});
+app.use(xrpc.xmlRpc);
 
 app.post('/RPC', xrpc.route({
     echo: function (msg, callback) {

--- a/xmlrpc.js
+++ b/xmlrpc.js
@@ -92,6 +92,7 @@ exports.route = function route(handlers) {
     }
     return function (req, res, next) {
 
+        res.type('text/xml');
         var cb = function (err, rv) {
             if (!err) {
                 res.send(new XmlRpcResponse([rv]).xml());


### PR DESCRIPTION
I have added in `xrpc.route` the default type `text/xml`, because normally return a response without content type.
Also I have fixed one typo in `package.js` (one comma missing) and I have remove `app.configure` method because it is deprecated in express